### PR TITLE
Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ app/build
 local.properties
 build/
 *.iml
-.gradle
+.gradle/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ app/build
 local.properties
 build/
 *.iml
+.gradle

--- a/app/src/main/java/com/example/ellioc/hearhere/AudioEngine.java
+++ b/app/src/main/java/com/example/ellioc/hearhere/AudioEngine.java
@@ -204,10 +204,11 @@ public class AudioEngine extends Thread {
         }catch (Exception e){
             e.printStackTrace();
         }
-        if(recordInstance != null){
-            recordInstance.stop();
-            recordInstance.release();
-            recordInstance = null;
+        finally {
+            if(recordInstance != null &&recordInstance.getState() == AudioRecord.STATE_INITIALIZED) {
+                recordInstance.stop();
+                recordInstance.release();
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/ellioc/hearhere/CalibrationFragment.java
+++ b/app/src/main/java/com/example/ellioc/hearhere/CalibrationFragment.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.support.v4.app.Fragment;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -42,7 +43,7 @@ public class CalibrationFragment extends Fragment {
             "C",
             "D",
             "E",
-            "F" };
+            "F"};
     AudioEngine audioEngine = null;
     ArrayAdapter<CharSequence> adapter = null;
     Spinner spinner = null;
@@ -51,7 +52,7 @@ public class CalibrationFragment extends Fragment {
     private SharedPreferences preferences;
 
 
-    private static HashMap<String, ArrayList<Integer>> calibrationValues = new HashMap<String, ArrayList<Integer>>(){{
+    private static HashMap<String, ArrayList<Integer>> calibrationValues = new HashMap<String, ArrayList<Integer>>() {{
         put("A", new ArrayList<Integer>());
         put("B", new ArrayList<Integer>());
         put("C", new ArrayList<Integer>());
@@ -61,25 +62,25 @@ public class CalibrationFragment extends Fragment {
     }};
 
     private static HashMap<String, Integer> thresholds = new HashMap<String, Integer>() {{
-        put("A",0);
-        put("B",0);
-        put("C",0);
-        put("D",0);
-        put("E",0);
+        put("A", 0);
+        put("B", 0);
+        put("C", 0);
+        put("D", 0);
+        put("E", 0);
         put("F", 0);
     }};
 
-    Handler mhandle = new Handler(new Handler.Callback(){
+    Handler mhandle = new Handler(new Handler.Callback() {
         @Override
-        public boolean handleMessage(Message msg){
-            switch (msg.what){
+        public boolean handleMessage(Message msg) {
+            switch (msg.what) {
                 case CLASSIFICATION:
                     int location = msg.arg1;
                     Log.i("Calibration: ", "returned value is " + location);
                     String selectedSection = spinner.getSelectedItem().toString();
                     ArrayList<Integer> selectedCalibrationValues = calibrationValues.get(selectedSection);
                     selectedCalibrationValues.add(location);
-                    if(selectedCalibrationValues.size() >= 5){
+                    if (selectedCalibrationValues.size() >= 5) {
                         stopAudioEngine();
                         updateThresholds();
                     }
@@ -91,7 +92,7 @@ public class CalibrationFragment extends Fragment {
 
     OnSubmitCalibrationValuesListener onSubmitCalibrationValuesListener;
 
-    public interface OnSubmitCalibrationValuesListener{
+    public interface OnSubmitCalibrationValuesListener {
         void onSubmitCalibrationValues(int requestCode, int resultCode, Intent data);
     }
 
@@ -102,6 +103,7 @@ public class CalibrationFragment extends Fragment {
     /**
      * Use this factory method to create a new instance of
      * this fragment using the provided parameters.
+     *
      * @return A new instance of fragment CalibrationFragment.
      */
     public static CalibrationFragment newInstance() {
@@ -140,9 +142,9 @@ public class CalibrationFragment extends Fragment {
         assert finishCalibrate != null;
         finishCalibrate.setVisibility(View.INVISIBLE);
         finishCalibrate.setOnClickListener(
-                new View.OnClickListener(){
+                new View.OnClickListener() {
                     @Override
-                    public void onClick(View v){
+                    public void onClick(View v) {
                         ArrayList<Integer> calibVals = new ArrayList<>();
                         Intent data = new Intent();
                         calibVals.add(thresholds.get("A"));
@@ -159,21 +161,16 @@ public class CalibrationFragment extends Fragment {
 //                        data.putExtra(GameFragment.KEY_CALIBRATION_E, thresholds.get("E"));
 //                        data.putExtra(GameFragment.KEY_CALIBRATION_F, thresholds.get("F"));
 
-                        Log.i(GameFragment.KEY_CALIBRATION_A,  Integer.toString(thresholds.get("A") ));
-                        Log.i(GameFragment.KEY_CALIBRATION_B,   Integer.toString(thresholds.get("B") ));
-                        Log.i(GameFragment.KEY_CALIBRATION_C, Integer.toString(thresholds.get("C") ) );
-                        Log.i(GameFragment.KEY_CALIBRATION_D,  Integer.toString(thresholds.get("D") )  );
-                        Log.i(GameFragment.KEY_CALIBRATION_E,   Integer.toString(thresholds.get("E") )   );
-                        Log.i(GameFragment.KEY_CALIBRATION_F, Integer.toString(thresholds.get("F") ) );
+                        Log.i(GameFragment.KEY_CALIBRATION_A, Integer.toString(thresholds.get("A")));
+                        Log.i(GameFragment.KEY_CALIBRATION_B, Integer.toString(thresholds.get("B")));
+                        Log.i(GameFragment.KEY_CALIBRATION_C, Integer.toString(thresholds.get("C")));
+                        Log.i(GameFragment.KEY_CALIBRATION_D, Integer.toString(thresholds.get("D")));
+                        Log.i(GameFragment.KEY_CALIBRATION_E, Integer.toString(thresholds.get("E")));
+                        Log.i(GameFragment.KEY_CALIBRATION_F, Integer.toString(thresholds.get("F")));
 
                         preferences = getActivity().getSharedPreferences(MainActivity.PREF_FILE_NAME, 0);
-                        String preference = "";
-                        for(int val : calibVals){
-                            preference += Integer.toString(val);
-                            if(val != calibVals.get(calibVals.size() - 1)){
-                                preference += ",";
-                            }
-                        }
+                        String preference = TextUtils.join(",", calibVals);
+
                         SharedPreferences.Editor prefEditor = preferences.edit();
                         prefEditor.putString(GameFragment.KEY_CALIBRATION, preference);
                         prefEditor.apply();
@@ -209,6 +206,12 @@ public class CalibrationFragment extends Fragment {
     public void onDetach() {
         super.onDetach();
         onSubmitCalibrationValuesListener = null;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        startAudioEngine();
     }
 
     public void onPause(){

--- a/app/src/main/java/com/example/ellioc/hearhere/CalibrationFragment.java
+++ b/app/src/main/java/com/example/ellioc/hearhere/CalibrationFragment.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.ProgressBar;
 import android.widget.Spinner;
 import android.widget.Toast;
 
@@ -51,6 +52,8 @@ public class CalibrationFragment extends Fragment {
     private Button finishCalibrate = null;
     private Button startCalibrate = null;
     private Button recalibrateButton = null;
+    private ProgressBar calibrateProgress = null;
+    private int mProgressStatus = 0;
 
 
     private static HashMap<String, ArrayList<Integer>> calibrationValues = new HashMap<String, ArrayList<Integer>>() {{
@@ -80,11 +83,14 @@ public class CalibrationFragment extends Fragment {
                     Log.i("Calibration: ", "returned value is " + location);
                     String selectedSection = spinner.getSelectedItem().toString();
                     ArrayList<Integer> selectedCalibrationValues = calibrationValues.get(selectedSection);
+                    mProgressStatus++;
                     selectedCalibrationValues.add(location);
                     if (selectedCalibrationValues.size() >= 5) {
                         stopAudioEngine();
                         updateThresholds();
+                        mProgressStatus = 0;
                     }
+                    calibrateProgress.setProgress(mProgressStatus);
                     break;
             }
             return true;
@@ -129,6 +135,9 @@ public class CalibrationFragment extends Fragment {
         assert spinner != null;
         spinner.setAdapter(adapter);
         this.setupButtons(view);
+
+        calibrateProgress = (ProgressBar) view.findViewById(R.id.progressBar);
+        calibrateProgress.setProgress(mProgressStatus);
 
         return view;
     }

--- a/app/src/main/java/com/example/ellioc/hearhere/CalibrationFragment.java
+++ b/app/src/main/java/com/example/ellioc/hearhere/CalibrationFragment.java
@@ -240,7 +240,7 @@ public class CalibrationFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        if(!startCalibrate.isClickable()){
+        if(!startCalibrate.isClickable() || !recalibrateButton.isClickable()) {
             startAudioEngine();
         }
     }

--- a/app/src/main/java/com/example/ellioc/hearhere/CalibrationFragment.java
+++ b/app/src/main/java/com/example/ellioc/hearhere/CalibrationFragment.java
@@ -49,6 +49,7 @@ public class CalibrationFragment extends Fragment {
     Spinner spinner = null;
     private Button finishCalibrate = null;
     private Button startCalibrate = null;
+    private Button recalibrateButton = null;
     private SharedPreferences preferences;
 
 
@@ -138,6 +139,14 @@ public class CalibrationFragment extends Fragment {
                     }
                 }
         );
+        recalibrateButton = (Button) view.findViewById(R.id.recalibrate);
+        recalibrateButton.setVisibility(View.INVISIBLE);
+        recalibrateButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+
+            }
+        });
         finishCalibrate = (Button) view.findViewById(R.id.finishCalibration);
         assert finishCalibrate != null;
         finishCalibrate.setVisibility(View.INVISIBLE);
@@ -211,14 +220,18 @@ public class CalibrationFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        startAudioEngine();
+        if(!startCalibrate.isClickable()){
+            startAudioEngine();
+        }
     }
 
+    @Override
     public void onPause(){
         super.onPause();
         stopAudioEngine();
     }
 
+    @Override
     public void onStop(){
         super.onStop();
         stopAudioEngine();

--- a/app/src/main/java/com/example/ellioc/hearhere/MainActivity.java
+++ b/app/src/main/java/com/example/ellioc/hearhere/MainActivity.java
@@ -216,19 +216,13 @@ public class MainActivity extends AppCompatActivity implements CalibrationFragme
     public void selectDrawerItem(MenuItem menuItem) {
         // Create a new fragment and specify the fragment to show based on nav item clicked
         Fragment fragment = null;
-        Class fragmentClass;
+        Class fragmentClass = null;
         switch(menuItem.getItemId()) {
             case R.id.nav_first_fragment:
                 fragmentClass = CalibrationFragment.class;
                 break;
             case R.id.nav_second_fragment:
-                if(IS_CALIBRATED) {
-                    fragmentClass = GameFragment.class;
-                    fragment = GameFragment.newInstance(
-                            calibValues
-                    );
-                }
-                else{
+                if(!IS_CALIBRATED){
                     SharedPreferences sharedPreferences = getSharedPreferences(PREF_FILE_NAME, 0);
                     String prefString = sharedPreferences.getString(GameFragment.KEY_CALIBRATION, "");
                     AlertDialog.Builder builder = new AlertDialog.Builder(this);
@@ -256,9 +250,6 @@ public class MainActivity extends AppCompatActivity implements CalibrationFragme
                             }
                         });
                         fragmentClass = GameFragment.class;
-                        fragment = GameFragment.newInstance(
-                                calibValues
-                        );
                     }
                     builder.create().show();
                 }
@@ -273,6 +264,9 @@ public class MainActivity extends AppCompatActivity implements CalibrationFragme
         try {
             if(fragmentClass != GameFragment.class) {
                 fragment = (Fragment) fragmentClass.newInstance();
+            }
+            else {
+                fragment = GameFragment.newInstance(calibValues);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/app/src/main/java/com/example/ellioc/hearhere/MainActivity.java
+++ b/app/src/main/java/com/example/ellioc/hearhere/MainActivity.java
@@ -241,7 +241,6 @@ public class MainActivity extends AppCompatActivity implements CalibrationFragme
                             public void onClick(DialogInterface dialog, int which) {
                             }
                         });
-                        builder.create().show();
                         fragmentClass = CalibrationFragment.class;
                     }
                     else{
@@ -261,7 +260,7 @@ public class MainActivity extends AppCompatActivity implements CalibrationFragme
                                 calibValues
                         );
                     }
-
+                    builder.create().show();
                 }
                 break;
             case R.id.nav_third_fragment:

--- a/app/src/main/java/com/example/ellioc/hearhere/MainActivity.java
+++ b/app/src/main/java/com/example/ellioc/hearhere/MainActivity.java
@@ -253,6 +253,9 @@ public class MainActivity extends AppCompatActivity implements CalibrationFragme
                     }
                     builder.create().show();
                 }
+                else {
+                    fragmentClass = GameFragment.class;
+                }
                 break;
             case R.id.nav_third_fragment:
                 fragmentClass = WelcomeScreenFragment.class;

--- a/app/src/main/res/layout/calibration_fragment.xml
+++ b/app/src/main/res/layout/calibration_fragment.xml
@@ -33,4 +33,13 @@
             android:layout_below="@+id/startCalibration"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="42dp" />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/recalibrate"
+            android:id="@+id/recalibrate"
+            android:layout_below="@+id/startCalibration"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="42dp" />
     </RelativeLayout>

--- a/app/src/main/res/layout/calibration_fragment.xml
+++ b/app/src/main/res/layout/calibration_fragment.xml
@@ -28,18 +28,31 @@
         <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:text="@string/recalibrate"
+            android:id="@+id/recalibrate"
+            android:layout_centerHorizontal="true"
+            android:layout_centerVertical="true"/>
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:text="@string/finish_calibration"
             android:id="@+id/finishCalibration"
             android:layout_below="@+id/startCalibration"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="42dp" />
 
-        <Button
-            android:layout_width="wrap_content"
+
+
+        <ProgressBar
+            style="@android:style/Widget.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/recalibrate"
-            android:id="@+id/recalibrate"
-            android:layout_below="@+id/startCalibration"
-            android:layout_centerHorizontal="true"
-            android:layout_marginTop="42dp" />
+            android:id="@+id/progressBar"
+            android:layout_below="@+id/finishCalibration"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_marginTop="24dp"
+            android:max="5"/>
+
     </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="title_activity_main2">Main2Activity</string>
     <string name="calibrate">Calibrate</string>
     <string name="finish_calibration">Finish Calibration</string>
+    <string name="recalibrate">Recalibrate</string>
 
     <string name="hello_blank_fragment">Welcome to HearHere!</string>
     <string name="welcome_description">

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 21 11:34:03 PDT 2015
+#Wed Sep 21 11:55:40 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
## onResume Callback
- Added the `onResume` callback which fixes a bug in which if a user presses the calibrate or recalibrate button and turns the screen off, the `audioEngine` could not be restarted by pressing the button again.
## SharedPreferences storage
- Bug with SharedPreferences caused when creating the string to push into storage. If a calibrated value had the same value as the last calibrated value of the calibValues list, a comma would not be inserted. Utilized TextUtils class to join the list with commas instead.
## Recalibration
- Added a recalibrate button that would appear if preset calibration values were already present or set.
  Issue #4 
## Dialog Box
- Fixed bug that would not display the dialog box when navigating to the `GameFragment` when calibration values were preset.
#### Refactoring
- Refactored some code in `MainActivity` in the fragment factories to reduce code bloat.
