### PR TITLE
Recalibration feature

### DIFF
--- a/app/src/main/java/com/example/ellioc/hearhere/MainActivity.java
+++ b/app/src/main/java/com/example/ellioc/hearhere/MainActivity.java
@@ -228,7 +228,7 @@ public class MainActivity extends AppCompatActivity implements CalibrationFragme
                     AlertDialog.Builder builder = new AlertDialog.Builder(this);
                     calibValues = new ArrayList<>();
                     builder.setTitle("Alert!!!!");
-                    if(prefString.equals("")) {
+                    if(prefString.contains(Integer.toString(Integer.MAX_VALUE))) {
                         builder.setMessage("Cannot begin HearHere until locations are calibrated!");
                         builder.setPositiveButton("Okay", new DialogInterface.OnClickListener() {
                             @Override

--- a/app/src/main/res/layout/calibration_fragment.xml
+++ b/app/src/main/res/layout/calibration_fragment.xml
@@ -28,14 +28,6 @@
         <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/recalibrate"
-            android:id="@+id/recalibrate"
-            android:layout_centerHorizontal="true"
-            android:layout_centerVertical="true"/>
-
-        <Button
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:text="@string/finish_calibration"
             android:id="@+id/finishCalibration"
             android:layout_below="@+id/startCalibration"

--- a/app/src/main/res/menu/drawer_view.xml
+++ b/app/src/main/res/menu/drawer_view.xml
@@ -2,14 +2,15 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <group android:checkableBehavior="single">
         <item
+            android:id="@+id/nav_third_fragment"
+            android:title="Welcome Screen"
+            android:checked="true"/>
+        <item
             android:id="@+id/nav_first_fragment"
             android:title="Calibration" />
         <item
             android:id="@+id/nav_second_fragment"
             android:title="HearHere" />
-        <item
-            android:id="@+id/nav_third_fragment"
-            android:title="Welcome Screen"
-            android:checked="true"/>
+
     </group>
 </menu>


### PR DESCRIPTION
## Recalibration
- `CalibrationFragment` now grabs stored thresholds in `SharedPreferences` if it exists.
  - If there were no previous calibration data, set the thresholds as `Integer.MAX_VALUE`.
  - Changed default threshold value from `0` to `Integer.MAX_VALUE` because `0` can be an actual threshold value.
- Calibration button changes between **Calibrate** and **Recalibrate** depending on whether the section had been previously calibrated.
## Shared Preferences
- Upon leaving the `CalibrationFragment` thresholds are automatically saved into `SharedPreferences` to prevent loss of data.
  - Functionality implemented in the `onStop()` callback.
## Documentation
- Renamed button and spinner variables to provide clearer semantics.
